### PR TITLE
Missing ';' in documentation- swap-tokens.md

### DIFF
--- a/versioned_docs/version-V2.1/guides/swap-tokens.md
+++ b/versioned_docs/version-V2.1/guides/swap-tokens.md
@@ -67,7 +67,7 @@ path.versions = versions;
 path.tokenPath = tokenPath;
 
 (, uint128 amountOut, ) = router.getSwapOut(pair, amountIn, true);
-uint256 amountOutWithSlippage = amountOut * 99 / 100 // We allow for 1% slippage
+uint256 amountOutWithSlippage = amountOut * 99 / 100; // We allow for 1% slippage
 uint256 amountOutReal = router.swapExactTokensForTokens(amountIn, amountOutWithSlippage, path, to, block.timestamp + 1);
 ```
 
@@ -92,7 +92,7 @@ path.versions = versions;
 path.tokenPath = tokenPath;
 
 (, uint256 amountOut, ) = router.getSwapOut(pairWavax, amountIn, false);
-uint256 amountOutWithSlippage = amountOut * 99 / 100 // We allow for 1% slippage
+uint256 amountOutWithSlippage = amountOut * 99 / 100; // We allow for 1% slippage
 uint256 amountOutReal = router.swapExactNATIVEForTokens{value: amountIn}(amountOutWithSlippage, path, to, block.timestamp + 1);
 ```
 


### PR DESCRIPTION
This line in the example code lacks a semicolon.

uint256 amountOutWithSlippage = amountOut * 99 / 100 // We allow for 1% slippage

It should be :
uint256 amountOutWithSlippage = amountOut * 99 / 100; // We allow for 1% slippage